### PR TITLE
Improve HF integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,21 @@ conda env create -f environment.yaml
 
 
 ## Inference with pretrained upsamplers
+
+All pre-trained upsamplers are available on 🤗 here: https://huggingface.co/models?search=loftup.
+
 We provide example code for using LoftUp in [example_usage.py](example_usage.py). Currently we provide:
 
 
-|Backbone Name          | Featurizer Class              | Download                                  | Torch Hub Repo | Torch Hub Name |
+|Backbone Name          | Featurizer Class              | HF hub                                  | Torch Hub Repo | Torch Hub Name |
 |-------------------| ---|------------------------------------------------|------|-----|
-| DINOv2 S/14     | [dinov2](featurizers/DINOv2.py)     | [Google Drive Link](https://drive.google.com/file/d/1Sse4gq2dCSNT-rnTVja7pG9ogIGfT0Ue/view?usp=drive_link)   | andrehuang/loftup | loftup_dinov2s|
-| DINOv2 S/14 + Reg | [dinov2s_reg](featurizers/DINOv2.py)     | [Google Drive Link](https://drive.google.com/file/d/1gzLyt4vPKZvWxt_9f8whUt9rOT0LkFlH/view?usp=drive_link)| andrehuang/loftup | loftup_dinov2s_reg|
-| DINOv2 B/14 | [dinov2b](featurizers/DINOv2.py) | [Google Drive Link](https://drive.google.com/file/d/1OloNcimH4u4LGw1G07i5BAcinFHiofsn/view?usp=sharing) | andrehuang/loftup | loftup_dinov2b|
-| DINOv2 B/14 + Reg | [dinov2b_reg](featurizers/DINOv2.py)     | [Google Drive Link](https://drive.google.com/file/d/1F-qES95VjQF_4gwigFWfJfVCLS9yaZ6w/view?usp=drive_link)|andrehuang/loftup | loftup_dinov2b_reg|
-| CLIP ViT B/16 | [clip](featurizers/CLIP.py) |[Google Drive Link](https://drive.google.com/file/d/18uBEvtugyidIu7r50A0Vk-e5vLSkUrcG/view?usp=drive_link) | andrehuang/loftup | loftup_clip|
-|SigLIP ViT B/16 | [siglip](featurizers/SigLIP.py) | [Google Drive Link](https://drive.google.com/file/d/1_hL1rCPbXg3HoJBfW5L_kRL9Zufa64lf/view?usp=drive_link)| andrehuang/loftup | loftup_siglip|
-|SigLIP2 ViT B/16 | [siglip2](featurizers/SigLIP.py) | [Google Drive Link](https://drive.google.com/file/d/1FnXbTqaf2ljy-TFVThalGS877oFO_rq5/view?usp=drive_link)| andrehuang/loftup | loftup_siglip2|
+| DINOv2 S/14     | [dinov2](featurizers/DINOv2.py)     | [haiwen/loftup-dinov2s](https://huggingface.co/haiwen/loftup-dinov2s)   | andrehuang/loftup | loftup_dinov2s|
+| DINOv2 S/14 + Reg | [dinov2s_reg](featurizers/DINOv2.py)     | [haiwen/loftup-dinov2s_reg](https://huggingface.co/haiwen/loftup-dinov2s_reg)| andrehuang/loftup | loftup_dinov2s_reg|
+| DINOv2 B/14 | [dinov2b](featurizers/DINOv2.py) | [haiwen/loftup-dinov2b](https://huggingface.co/haiwen/loftup-dinov2b) | andrehuang/loftup | loftup_dinov2b|
+| DINOv2 B/14 + Reg | [dinov2b_reg](featurizers/DINOv2.py)     | [haiwen/loftup-dinov2b_reg](https://huggingface.co/haiwen/loftup-dinov2b_reg)|andrehuang/loftup | loftup_dinov2b_reg|
+| CLIP ViT B/16 | [clip](featurizers/CLIP.py) |[haiwen/loftup-clip](https://huggingface.co/haiwen/loftup-clip) | andrehuang/loftup | loftup_clip|
+|SigLIP ViT B/16 | [siglip](featurizers/SigLIP.py) | [haiwen/loftup-siglip](https://huggingface.co/haiwen/loftup-siglip)| andrehuang/loftup | loftup_siglip|
+|SigLIP2 ViT B/16 | [siglip2](featurizers/SigLIP.py) | [haiwen/loftup-siglip2](https://huggingface.co/haiwen/loftup-siglip2)| andrehuang/loftup | loftup_siglip2|
 
 To use torch hub checkpoints, simply run 
 ```python

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-from huggingface_hub import PyTorchModelHubMixin
 from upsamplers.layers import ChannelNorm
 from upsamplers.upsamplers import LoftUp, UpsamplerwithChannelNorm
 from huggingface_hub import hf_hub_download

--- a/push_to_hf.py
+++ b/push_to_hf.py
@@ -5,29 +5,29 @@ This script can be used to push the LoftUp upsamplers to the Hugging Face Hub.
 import torch
 
 # push loftup-dinov2s
-model = torch.hub.load('andrehuang/loftup', 'loftup_dinov2s', pretrained=True)
+model = torch.hub.load('nielsrogge/loftup:add_hf', 'loftup_dinov2s', pretrained=True)
 model.upsampler.push_to_hub("nielsr/loftup-dinov2s")
 
 # push loftup-siglip2
-model = torch.hub.load('andrehuang/loftup', 'loftup_siglip2', pretrained=True)
+model = torch.hub.load('nielsrogge/loftup:add_hf', 'loftup_siglip2', pretrained=True)
 model.upsampler.push_to_hub("nielsr/loftup-siglip2")
 
 # push loftup-siglip
-model = torch.hub.load('andrehuang/loftup', 'loftup_siglip', pretrained=True)
+model = torch.hub.load('nielsrogge/loftup:add_hf', 'loftup_siglip', pretrained=True)
 model.upsampler.push_to_hub("nielsr/loftup-siglip")
 
 # push loftup-dinov2b
-model = torch.hub.load('andrehuang/loftup', 'loftup_dinov2b', pretrained=True)
+model = torch.hub.load('nielsrogge/loftup:add_hf', 'loftup_dinov2b', pretrained=True)
 model.upsampler.push_to_hub("nielsr/loftup-dinov2b")
 
 # push loftup-dinov2s_reg
-model = torch.hub.load('andrehuang/loftup', 'loftup_dinov2s_reg', pretrained=True)
+model = torch.hub.load('nielsrogge/loftup:add_hf', 'loftup_dinov2s_reg', pretrained=True)
 model.upsampler.push_to_hub("nielsr/loftup-dinov2s_reg")
 
 # push loftup-dinov2b_reg
-model = torch.hub.load('andrehuang/loftup', 'loftup_dinov2b_reg', pretrained=True)
+model = torch.hub.load('nielsrogge/loftup:add_hf', 'loftup_dinov2b_reg', pretrained=True)
 model.upsampler.push_to_hub("nielsr/loftup-dinov2b_reg")
 
 # push loftup-clip
-model = torch.hub.load('andrehuang/loftup', 'loftup_clip', pretrained=True)
+model = torch.hub.load('nielsrogge/loftup:add_hf', 'loftup_clip', pretrained=True)
 model.upsampler.push_to_hub("nielsr/loftup-clip")

--- a/push_to_hf.py
+++ b/push_to_hf.py
@@ -5,29 +5,29 @@ This script can be used to push the LoftUp upsamplers to the Hugging Face Hub.
 import torch
 
 # push loftup-dinov2s
-upsampler = torch.hub.load('andrehuang/loftup', 'loftup_dinov2s', pretrained=True)
-upsampler.push_to_hub("haiwen/loftup-dinov2s")
+model = torch.hub.load('andrehuang/loftup', 'loftup_dinov2s', pretrained=True)
+model.upsampler.push_to_hub("nielsr/loftup-dinov2s")
 
 # push loftup-siglip2
-upsampler = torch.hub.load('andrehuang/loftup', 'loftup_siglip2', pretrained=True)
-upsampler.push_to_hub("haiwen/loftup-siglip2")
+model = torch.hub.load('andrehuang/loftup', 'loftup_siglip2', pretrained=True)
+model.upsampler.push_to_hub("nielsr/loftup-siglip2")
 
 # push loftup-siglip
-upsampler = torch.hub.load('andrehuang/loftup', 'loftup_siglip', pretrained=True)
-upsampler.push_to_hub("haiwen/loftup-siglip")
+model = torch.hub.load('andrehuang/loftup', 'loftup_siglip', pretrained=True)
+model.upsampler.push_to_hub("nielsr/loftup-siglip")
 
 # push loftup-dinov2b
-upsampler = torch.hub.load('andrehuang/loftup', 'loftup_dinov2b', pretrained=True)
-upsampler.push_to_hub("haiwen/loftup-dinov2b")
+model = torch.hub.load('andrehuang/loftup', 'loftup_dinov2b', pretrained=True)
+model.upsampler.push_to_hub("nielsr/loftup-dinov2b")
 
 # push loftup-dinov2s_reg
-upsampler = torch.hub.load('andrehuang/loftup', 'loftup_dinov2s_reg', pretrained=True)
-upsampler.push_to_hub("haiwen/loftup-dinov2s_reg")
+model = torch.hub.load('andrehuang/loftup', 'loftup_dinov2s_reg', pretrained=True)
+model.upsampler.push_to_hub("nielsr/loftup-dinov2s_reg")
 
 # push loftup-dinov2b_reg
-upsampler = torch.hub.load('andrehuang/loftup', 'loftup_dinov2b_reg', pretrained=True)
-upsampler.push_to_hub("haiwen/loftup-dinov2b_reg")
+model = torch.hub.load('andrehuang/loftup', 'loftup_dinov2b_reg', pretrained=True)
+model.upsampler.push_to_hub("nielsr/loftup-dinov2b_reg")
 
 # push loftup-clip
-upsampler = torch.hub.load('andrehuang/loftup', 'loftup_clip', pretrained=True)
-upsampler.push_to_hub("haiwen/loftup-clip")
+model = torch.hub.load('andrehuang/loftup', 'loftup_clip', pretrained=True)
+model.upsampler.push_to_hub("nielsr/loftup-clip")

--- a/push_to_hf.py
+++ b/push_to_hf.py
@@ -1,0 +1,33 @@
+"""
+This script can be used to push the LoftUp upsamplers to the Hugging Face Hub.
+"""
+
+import torch
+
+# push loftup-dinov2s
+upsampler = torch.hub.load('andrehuang/loftup', 'loftup_dinov2s', pretrained=True)
+upsampler.push_to_hub("haiwen/loftup-dinov2s")
+
+# push loftup-siglip2
+upsampler = torch.hub.load('andrehuang/loftup', 'loftup_siglip2', pretrained=True)
+upsampler.push_to_hub("haiwen/loftup-siglip2")
+
+# push loftup-siglip
+upsampler = torch.hub.load('andrehuang/loftup', 'loftup_siglip', pretrained=True)
+upsampler.push_to_hub("haiwen/loftup-siglip")
+
+# push loftup-dinov2b
+upsampler = torch.hub.load('andrehuang/loftup', 'loftup_dinov2b', pretrained=True)
+upsampler.push_to_hub("haiwen/loftup-dinov2b")
+
+# push loftup-dinov2s_reg
+upsampler = torch.hub.load('andrehuang/loftup', 'loftup_dinov2s_reg', pretrained=True)
+upsampler.push_to_hub("haiwen/loftup-dinov2s_reg")
+
+# push loftup-dinov2b_reg
+upsampler = torch.hub.load('andrehuang/loftup', 'loftup_dinov2b_reg', pretrained=True)
+upsampler.push_to_hub("haiwen/loftup-dinov2b_reg")
+
+# push loftup-clip
+upsampler = torch.hub.load('andrehuang/loftup', 'loftup_clip', pretrained=True)
+upsampler.push_to_hub("haiwen/loftup-clip")

--- a/upsamplers/upsamplers.py
+++ b/upsamplers/upsamplers.py
@@ -14,7 +14,11 @@ import numpy as np
 import torchvision.transforms as T
 from .layers import ChannelNorm, LayerNorm, MinMaxScaler, ImplicitFeaturizer, CATransformer
 
-class LoftUp(nn.Module):
+class LoftUp(nn.Module, PyTorchModelHubMixin,
+             repo_url="https://github.com/andrehuang/loftup",
+             pipeline_tag="image-feature-extraction",
+             license="mit",
+             paper_url="https://huggingface.co/papers/2504.14032"):
     """
     We use Fourier features of images as inputs, and do cross attention with the LR features, the output is the HR features.
     """

--- a/upsamplers/upsamplers.py
+++ b/upsamplers/upsamplers.py
@@ -16,6 +16,7 @@ import numpy as np
 import torchvision.transforms as T
 from .layers import ChannelNorm, LayerNorm, MinMaxScaler, ImplicitFeaturizer, CATransformer
 
+
 class LoftUp(nn.Module, PyTorchModelHubMixin,
              repo_url="https://github.com/andrehuang/loftup",
              pipeline_tag="image-feature-extraction",

--- a/upsamplers/upsamplers.py
+++ b/upsamplers/upsamplers.py
@@ -6,6 +6,8 @@ from torchvision import transforms
 import torch.nn.functional as F
 from einops import rearrange
 
+from huggingface_hub import PyTorchModelHubMixin
+
 import math
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors


### PR DESCRIPTION
Hi @andrehuang,

Thanks for making the models available on 🤗.

This PR fixes some things regarding the integration with the hub, relying on the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.ModelHubMixin.example) class.

As can be seen, the only thing required is to equip the main LoftUp class with the Mixin class, and then you can run the `push_to_hf.py` script (assuming you're authenticated with your HF account).

Here are the pushed models: https://huggingface.co/models?search=nielsr/loftup.

This ensures:
- `safetensors` is adopted, as opposed to the `pytorch_model.bin` file for safer weights serialization
- download stats work for you as each repo has a `config.json` like here: https://huggingface.co/nielsr/loftup-dinov2s/blob/main/config.json
- the models are linked to the [paper page](https://huggingface.co/papers/2504.14032).

Feel free to try out the `push_to_hf.py` script!
